### PR TITLE
Add sourceName/Category/Host metadata support for log4j appender

### DIFF
--- a/src/main/java/com/sumologic/log4j/SumoLogicAppender.java
+++ b/src/main/java/com/sumologic/log4j/SumoLogicAppender.java
@@ -72,18 +72,19 @@ public class SumoLogicAppender extends AbstractAppender {
                                 String url, ProxySettings proxySettings,
                                 Integer retryInterval, Integer connectionTimeout, Integer socketTimeout,
                                 Long messagesPerRequest, Long maxFlushInterval, String sourceName,
+                                String sourceCategory, String sourceHost,
                                 Long flushingAccuracy, Long maxQueueSizeBytes) {
         super(name, filter, layout, ignoreExceptions);
 
         // Initialize queue
-         queue = new BufferWithFifoEviction<String>(maxQueueSizeBytes, new CostBoundedConcurrentQueue.CostAssigner<String>() {
-             @Override
-             public long cost(String e) {
-                 // Note: This is only an estimate for total byte usage, since in UTF-8 encoding,
-                 // the size of one character may be > 1 byte.
-                 return e.length();
-             }
-         });
+        queue = new BufferWithFifoEviction<String>(maxQueueSizeBytes, new CostBoundedConcurrentQueue.CostAssigner<String>() {
+         @Override
+         public long cost(String e) {
+             // Note: This is only an estimate for total byte usage, since in UTF-8 encoding,
+             // the size of one character may be > 1 byte.
+             return e.length();
+         }
+        });
 
         // Initialize sender
         sender = new SumoHttpSender();
@@ -91,6 +92,9 @@ public class SumoLogicAppender extends AbstractAppender {
         sender.setConnectionTimeout(connectionTimeout);
         sender.setSocketTimeout(socketTimeout);
         sender.setUrl(url);
+        sender.setSourceName(sourceName);
+        sender.setSourceCategory(sourceCategory);
+        sender.setSourceHost(sourceHost);
         sender.setProxySettings(proxySettings);
         sender.init();
 
@@ -98,7 +102,6 @@ public class SumoLogicAppender extends AbstractAppender {
         flusher = new SumoBufferFlusher(flushingAccuracy,
                 messagesPerRequest,
                 maxFlushInterval,
-                sourceName,
                 sender,
                 queue);
         flusher.start();
@@ -122,6 +125,8 @@ public class SumoLogicAppender extends AbstractAppender {
             @PluginAttribute(value = "messagesPerRequest", defaultLong = DEFAULT_MESSAGES_PER_REQUEST) Long messagesPerRequest,
             @PluginAttribute(value = "maxFlushInterval", defaultLong = DEFAULT_MAX_FLUSH_INTERVAL) Long maxFlushInterval,
             @PluginAttribute(value = "sourceName") String sourceName,
+            @PluginAttribute(value = "sourceCategory") String sourceCategory,
+            @PluginAttribute(value = "sourceHost") String sourceHost,
             @PluginAttribute(value = "flushingAccuracy", defaultLong = DEFAULT_FLUSHING_ACCURACY) Long flushingAccuracy,
             @PluginAttribute(value = "maxQueueSizeBytes", defaultLong = DEFAULT_MAX_QUEUE_SIZE_BYTES) Long maxQueueSizeBytes) {
 
@@ -142,7 +147,8 @@ public class SumoLogicAppender extends AbstractAppender {
         ProxySettings proxySettings = new ProxySettings(proxyHost, proxyPort, proxyAuth, proxyUser, proxyPassword, proxyDomain);
 
         return new SumoLogicAppender(name, filter, layout, true, url, proxySettings, retryInterval, connectionTimeout,
-                socketTimeout, messagesPerRequest, maxFlushInterval, sourceName, flushingAccuracy, maxQueueSizeBytes);
+                socketTimeout, messagesPerRequest, maxFlushInterval, sourceName, sourceCategory,
+                sourceHost, flushingAccuracy, maxQueueSizeBytes);
     }
 
     public void append(LogEvent event) {

--- a/src/main/java/com/sumologic/log4j/aggregation/BufferFlushingTask.java
+++ b/src/main/java/com/sumologic/log4j/aggregation/BufferFlushingTask.java
@@ -61,7 +61,7 @@ public abstract class BufferFlushingTask<In, Out> implements Runnable {
                     messages.size(),
                     messageQueue.size()));
             Out body = aggregate(messages);
-            sendOut(body, getName());
+            sendOut(body);
             timeOfLastFlush = System.currentTimeMillis();
         }
     }
@@ -71,7 +71,6 @@ public abstract class BufferFlushingTask<In, Out> implements Runnable {
 
     abstract protected long getMaxFlushInterval();
     abstract protected long getMessagesPerRequest();
-    abstract protected String getName();
 
     protected BufferFlushingTask(BufferWithEviction<In> messageQueue) {
         this.messageQueue = messageQueue;
@@ -80,9 +79,7 @@ public abstract class BufferFlushingTask<In, Out> implements Runnable {
     // Given the list of messages, aggregate them into a single Out object
     abstract protected Out aggregate(List<In> messages);
     // Send aggregated message out. Block until we've successfully sent it.
-    abstract protected void sendOut(Out body, String name);
-
-
+    abstract protected void sendOut(Out body);
 
     /* Public interface */
 

--- a/src/main/java/com/sumologic/log4j/aggregation/SumoBufferFlusher.java
+++ b/src/main/java/com/sumologic/log4j/aggregation/SumoBufferFlusher.java
@@ -45,17 +45,12 @@ public class SumoBufferFlusher {
             long flushingAccuracy,
             long messagesPerRequest,
             long maxFlushInterval,
-            String sourceName,
             SumoHttpSender sender,
             BufferWithEviction<String> buffer) {
-
         this.flushingAccuracy = flushingAccuracy;
-
         flushingTask = new SumoBufferFlushingTask(buffer);
-
         flushingTask.setMessagesPerRequest(messagesPerRequest);
         flushingTask.setMaxFlushInterval(maxFlushInterval);
-        flushingTask.setName(sourceName);
         flushingTask.setSender(sender);
     }
 

--- a/src/main/java/com/sumologic/log4j/http/SumoBufferFlushingTask.java
+++ b/src/main/java/com/sumologic/log4j/http/SumoBufferFlushingTask.java
@@ -40,14 +40,9 @@ public class SumoBufferFlushingTask extends BufferFlushingTask<String, String> {
     private SumoHttpSender sender;
     private long maxFlushInterval;
     private long messagesPerRequest;
-    private String name;
 
     public SumoBufferFlushingTask(BufferWithEviction<String> queue) {
         super(queue);
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 
     public void setSender(SumoHttpSender sender) {
@@ -73,11 +68,6 @@ public class SumoBufferFlushingTask extends BufferFlushingTask<String, String> {
     }
 
     @Override
-    protected String getName() {
-        return name;
-    }
-
-    @Override
     protected String aggregate(List<String> messages) {
         StringBuilder builder = new StringBuilder(messages.size() * 10);
         for (String message: messages) {
@@ -87,10 +77,10 @@ public class SumoBufferFlushingTask extends BufferFlushingTask<String, String> {
     }
 
     @Override
-    protected void sendOut(String body, String name) {
+    protected void sendOut(String body) {
         if (sender != null && sender.isInitialized()) {
             logger.debug("Sending out data");
-            sender.send(body, name);
+            sender.send(body);
         } else {
             logger.error("HTTPSender is not initialized");
         }

--- a/src/main/java/com/sumologic/log4j/http/SumoHttpSender.java
+++ b/src/main/java/com/sumologic/log4j/http/SumoHttpSender.java
@@ -46,14 +46,19 @@ import java.io.IOException;
 public class SumoHttpSender {
     private static final Logger logger = StatusLogger.getLogger();
 
+    private static final String SUMO_SOURCE_NAME_HEADER = "X-Sumo-Name";
+    private static final String SUMO_SOURCE_CATEGORY_HEADER = "X-Sumo-Category";
+    private static final String SUMO_SOURCE_HOST_HEADER = "X-Sumo-Host";
+
     private long retryInterval = 10000L;
-
-    private volatile String url = null;
-    private volatile ProxySettings proxySettings = null;
-
     private int connectionTimeout = 1000;
     private int socketTimeout = 60000;
-    private volatile CloseableHttpClient httpClient = null;
+    private String url = null;
+    private String sourceName = null;
+    private String sourceCategory = null;
+    private String sourceHost = null;
+    private ProxySettings proxySettings = null;
+    private CloseableHttpClient httpClient = null;
 
     public ProxySettings getProxySettings() {
         return proxySettings;
@@ -69,6 +74,18 @@ public class SumoHttpSender {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public void setSourceName(String sourceName) {
+        this.sourceName = sourceName;
+    }
+
+    public void setSourceCategory(String sourceCategory) {
+        this.sourceCategory = sourceCategory;
+    }
+
+    public void setSourceHost(String sourceHost) {
+        this.sourceHost = sourceHost;
     }
 
     public void setConnectionTimeout(int connectionTimeout) {
@@ -104,15 +121,15 @@ public class SumoHttpSender {
         httpClient = null;
     }
 
-    public void send(String body, String name) {
-        keepTrying(body, name);
+    public void send(String body) {
+        keepTrying(body);
     }
 
-    private void keepTrying(String body, String name) {
+    private void keepTrying(String body) {
         boolean success = false;
         do {
             try {
-                trySend(body, name);
+                trySend(body);
                 success = true;
             } catch (Exception e) {
                 try {
@@ -124,16 +141,16 @@ public class SumoHttpSender {
         } while (!success && !Thread.currentThread().isInterrupted());
     }
 
-    private void trySend(String body, String name) throws IOException {
+    private void trySend(String body) throws IOException {
         HttpPost post = null;
         try {
             if (url == null)
                 throw new IOException("Unknown endpoint");
 
             post = new HttpPost(url);
-            if (name != null) {
-                post.setHeader("X-Sumo-Name", name);
-            }
+            safeSetHeader(post, SUMO_SOURCE_NAME_HEADER, sourceName);
+            safeSetHeader(post, SUMO_SOURCE_CATEGORY_HEADER, sourceCategory);
+            safeSetHeader(post, SUMO_SOURCE_HOST_HEADER, sourceHost);
             post.setEntity(new StringEntity(body, Consts.UTF_8));
             HttpResponse response = httpClient.execute(post);
             int statusCode = response.getStatusLine().getStatusCode();
@@ -155,6 +172,12 @@ public class SumoHttpSender {
             } catch (Exception ignore) {
             }
             throw e;
+        }
+    }
+
+    private void safeSetHeader(HttpPost post, String name, String value) {
+        if (value != null && !value.trim().isEmpty()) {
+            post.setHeader(name, value);
         }
     }
 }

--- a/src/test/java/com/sumologic/log4j/aggregation/BufferFlushingTaskTest.java
+++ b/src/test/java/com/sumologic/log4j/aggregation/BufferFlushingTaskTest.java
@@ -132,17 +132,12 @@ public class BufferFlushingTaskTest {
             }
 
             @Override
-            protected String getName() {
-                return "No-name";
-            }
-
-            @Override
             protected List<String> aggregate(List<String> messages) {
                 return messages;
             }
 
             @Override
-            protected void sendOut(List<String> body, String name) {
+            protected void sendOut(List<String> body) {
                 tasks.add(body);
             }
         };

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,8 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="info">
 <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+        <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
     <SumoLogicAppender
-            name="SumoAppender"
+            name="TestSumoAppender1"
+            url="http://localhost:10010"
+            sourceName="mySource"
+            sourceHost="myHost"
+            sourceCategory="myCategory"
+            messagesPerRequest="1"
+            maxFlushInterval="100"
+            flushingAccuracy="10">
+        <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss,SSS Z} [%t] %-5p %c - %m%n" />
+    </SumoLogicAppender>
+    <SumoLogicAppender
+            name="TestSumoAppender2"
             url="http://localhost:10010"
             messagesPerRequest="1"
             maxFlushInterval="100"
@@ -11,8 +25,14 @@
     </SumoLogicAppender>
 </Appenders>
 <Loggers>
-    <Root level="all" additivity="false">
-        <AppenderRef ref="SumoAppender" />
+    <Root level="all">
+        <AppenderRef ref="Console" />
     </Root>
+    <Logger name="TestAppender1" level="all">
+        <AppenderRef ref="TestSumoAppender1"/>
+    </Logger>
+    <Logger name="TestAppender2" level="all">
+        <AppenderRef ref="TestSumoAppender2"/>
+    </Logger>
 </Loggers>
 </Configuration>


### PR DESCRIPTION
This PR refactors existing support for `sourceName` metadata, and adds additional metadata fields for `sourceCategory` and `sourceHost` based on https://help.sumologic.com/Send-Data/Sources/02Sources-for-Hosted-Collectors/HTTP-Source/Upload-Data-to-an-HTTP-Source#Other_Supported_HTTP_Headers.