### PR TITLE
Add retryableHttpCodeRegex for configurable HTTP retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Be sure to replace [collector-url] with the URL after creating an HTTP Hosted Co
 | flushingAccuracy      | No       | 250           | How often (in ms) that the flushing thread checks the message queue                                                                        |
 | maxQueueSizeBytes     | No       | 1000000       | Maximum capacity (in bytes) of the message queue
 | flushAllBeforeStopping| No       | false         | Flush all messages before stopping regardless of flushingAccuracy
+| retryableHttpCodeRegex| No       | ^5.*         | Regular expression specifying which HTTP error code(s) should be retried during sending. By default, all 5xx error codes will be retried.
 
 #### Example with Optional Parameters
 `log4j2.xml`:

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
         <dependency>
             <groupId>com.sumologic.plugins.http</groupId>
             <artifactId>sumologic-http-core</artifactId>
-            <version>1.1</version>
+            <version>1.4</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Adds a parameter for `retryableHttpCodeRegex` that is configurable with a regex string.  By default we have it match `^5.*` for all 5xx, but the user can override it however they want with a regular expression.