### PR TITLE
Aligned versions dependencies with the sumologic-http-core lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,12 +116,10 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -116,11 +116,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
+            <version>2.12.1</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
+            <version>4.12</version>
         </dependency>
         <dependency>
             <groupId>com.sumologic.plugins.http</groupId>


### PR DESCRIPTION
The `sumologic-http-core` v1.5 lib defined the higher versions of the dependant libraries than this dependent project.

I think it should be the same. 