### PR TITLE
Release process - not closing on failures during release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
                     <serverId>sonatype-nexus-staging</serverId>
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
+                    <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This is to counter some `mvn deploy` problems like timeout (with no errors).