### PR TITLE
Requiring Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.10.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
For no specific reason other than avoiding problems like #39.
Also Java 1.6 is 16yo as of now.

Switching to Java 8 which is a safe LTS bet.