### PR TITLE
fix system dependent test SumoLogicAppenderTest.testMessagesWithMetadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://api.travis-ci.org/SumoLogic/sumologic-log4j2-appender.svg?branch=master)](https://travis-ci.org/SumoLogic/sumologic-log4j2-appender)
+[![Build Status](https://app.travis-ci.com/SumoLogic/sumologic-log4j2-appender.svg?branch=master)](https://app.travis-ci.com/github/SumoLogic/sumologic-log4j2-appender?branch=master)
 [![codecov.io](https://codecov.io/github/SumoLogic/sumologic-log4j2-appender/coverage.svg?branch=master)](https://codecov.io/github/SumoLogic/sumologic-log4j2-appender?branch=master)
 
 # sumologic-log4j2-appender

--- a/src/test/java/com/sumologic/log4j/SumoLogicAppenderTest.java
+++ b/src/test/java/com/sumologic/log4j/SumoLogicAppenderTest.java
@@ -78,7 +78,7 @@ public class SumoLogicAppenderTest {
         // Check body
         StringBuffer actual = new StringBuffer();
         for(MaterializedHttpRequest request: handler.getExchanges()) {
-            for (String line : request.getBody().split("\n")) {
+            for (String line : request.getBody().split(System.lineSeparator())) {
                 // Strip timestamp
                 int mainStart = line.indexOf("[main]");
                 String trimmed = line.substring(mainStart);


### PR DESCRIPTION
Test ` SumoLogicAppenderTest.testMessagesWithMetadata()` is dependent to unix systems by using hardcoded line separator "\n". I changed the hardcoded lineSeparator to ` System.lineSeparator()` to make it independent. fixes #50 