### PR TITLE
SumoLogicAppenderTest cleanup and new tests for SumoLogicAppender.newBuilder()

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,29 +54,29 @@ Be sure to replace [collector-url] with the URL after creating an HTTP Hosted Co
 2. Sumo only supports [certain time formats](https://help.sumologic.com/03Send-Data/Sources/04Reference-Information-for-Sources/Timestamps%2C-Time-Zones%2C-Time-Ranges%2C-and-Date-Formats), and accidentally using an invalid time format could cause [message time discrepancies](https://help.sumologic.com/03Send-Data/Collector-FAQs/Troubleshooting-time-discrepancies).
 
 ### Parameters
-| Parameter             | Required? | Default Value | Description                                                                                                                                |
-|-----------------------|----------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------|
-| name                  | Yes      |               | Name used to register Log4j Appender                                                                                                       |
-| url                   | Yes      |               | HTTP collection endpoint URL                                                                                                               |
-| sourceName            | No       | "Http Input"              | Source name to appear when searching on Sumo Logic by `_sourceName`                                                                                                        |
-| sourceHost            | No       | Client IP Address              | Source host to appear when searching on Sumo Logic by `_sourceHost`                                                                                                         |
-| sourceCategory        | No       | "Http Input"              | Source category to appear when searching on Sumo Logic by `_sourceCategory`                                                                                                         |
-| proxyHost             | No       |               | Proxy host IP address                                                                                                                      |
-| proxyPort             | No       |               | Proxy host port number                                                                                                                     |
-| proxyAuth             | No       |               | For basic authentication proxy, set to "basic". For NTLM authentication proxy, set to "ntlm". For no authentication proxy, do not specify. |
-| proxyUser             | No       |               | Proxy host username for basic and NTLM authentication. For no authentication proxy, do not specify.                                        |
-| proxyPassword         | No       |               | Proxy host password for basic and NTLM authentication. For no authentication proxy, do not specify.                                        |
-| proxyDomain           | No       |               | Proxy host domain name for NTLM authentication only                                                                                        |
-| retryInterval         | No       | 10000         | Retry interval (in ms) if a request fails                                                                                                  |
-| maxNumberOfRetries    | No       | -1            | Maximum number of retries before a message is dropped. Negative values represent no limit on retries.                                      |
-| connectionTimeout     | No       | 1000          | Timeout (in ms) for connection                                                                                                             |
-| socketTimeout         | No       | 60000         | Timeout (in ms) for a socket                                                                                                               |
-| messagesPerRequest    | No       | 100           | Number of messages needed to be in the queue before flushing                                                                               |
-| maxFlushInterval      | No       | 10000         | Maximum interval (in ms) between flushes                                                                                                   |
-| flushingAccuracy      | No       | 250           | How often (in ms) that the flushing thread checks the message queue                                                                        |
-| maxQueueSizeBytes     | No       | 1000000       | Maximum capacity (in bytes) of the message queue
-| flushAllBeforeStopping| No       | false         | Flush all messages before stopping regardless of flushingAccuracy
-| retryableHttpCodeRegex| No       | ^5.*         | Regular expression specifying which HTTP error code(s) should be retried during sending. By default, all 5xx error codes will be retried.
+| Parameter              | Required? | Default Value     | Description                                                                                                                                |
+|------------------------|-----------|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| name                   | Yes       |                   | Name used to register Log4j Appender                                                                                                       |
+| url                    | Yes       |                   | HTTP collection endpoint URL                                                                                                               |
+| sourceName             | No        | "Http Input"      | Source name to appear when searching on Sumo Logic by `_sourceName`                                                                        |
+| sourceHost             | No        | Client IP Address | Source host to appear when searching on Sumo Logic by `_sourceHost`                                                                        |
+| sourceCategory         | No        | "Http Input"      | Source category to appear when searching on Sumo Logic by `_sourceCategory`                                                                |
+| proxyHost              | No        |                   | Proxy host IP address                                                                                                                      |
+| proxyPort              | No        |                   | Proxy host port number                                                                                                                     |
+| proxyAuth              | No        |                   | For basic authentication proxy, set to "basic". For NTLM authentication proxy, set to "ntlm". For no authentication proxy, do not specify. |
+| proxyUser              | No        |                   | Proxy host username for basic and NTLM authentication. For no authentication proxy, do not specify.                                        |
+| proxyPassword          | No        |                   | Proxy host password for basic and NTLM authentication. For no authentication proxy, do not specify.                                        |
+| proxyDomain            | No        |                   | Proxy host domain name for NTLM authentication only                                                                                        |
+| retryInterval          | No        | 10000             | Retry interval (in ms) if a request fails                                                                                                  |
+| maxNumberOfRetries     | No        | -1                | Maximum number of retries before a message is dropped. Negative values represent no limit on retries.                                      |
+| connectionTimeout      | No        | 1000              | Timeout (in ms) for connection                                                                                                             |
+| socketTimeout          | No        | 60000             | Timeout (in ms) for a socket                                                                                                               |
+| messagesPerRequest     | No        | 100               | Number of messages needed to be in the queue before flushing                                                                               |
+| maxFlushInterval       | No        | 10000             | Maximum interval (in ms) between flushes                                                                                                   |
+| flushingAccuracy       | No        | 250               | How often (in ms) that the flushing thread checks the message queue                                                                        |
+| maxQueueSizeBytes      | No        | 1000000           | Maximum capacity (in bytes) of the message queue                                                                                           |
+| flushAllBeforeStopping | No        | false             | Flush all messages before stopping regardless of flushingAccuracy                                                                          |
+| retryableHttpCodeRegex | No        | ^5.*              | Regular expression specifying which HTTP error code(s) should be retried during sending. By default, all 5xx error codes will be retried.  |
 
 #### Example with Optional Parameters
 `log4j2.xml`:


### PR DESCRIPTION
I did some small improvements in `README.md` (add borders/pipe symbols) to all table rows, cleaned up some unnecessary code in `SumoLogicAppenderTest` and wrote some new tests for the builder of `SumoLogicAppender`. There were also some occurrences left of hardcoded newLine characters `\n` in the tests which have been cleaned up as well. (see #51)